### PR TITLE
Fixed NullReferenceException caused by GetIsAttachedToCore

### DIFF
--- a/Robot Building Lab/Assets/Scripts/BuildingBlock.cs
+++ b/Robot Building Lab/Assets/Scripts/BuildingBlock.cs
@@ -20,14 +20,20 @@ public class BuildingBlock : MonoBehaviour
 
     public bool GetIsAttachedToCore()
     {
-        return transform.root.GetComponent<BuildingBlock>().isCoreBlock;
+        if (transform.root.TryGetComponent(out BuildingBlock root))
+            return root.isCoreBlock;
+        else
+            return false;   //< If the root of this building block is (for whatever reason) not a building block
     }
 
     /// <returns>
     /// Success of the operation. False if connector was already registered as active connection.
     /// </returns>
-    public bool AddCoreConnection(Connector ownedConnector)
+    public bool RegisterCoreConnection(Connector ownedConnector)
     {
+        if (isCoreBlock)
+            return false;
+
         if (!activeConnections.Contains(ownedConnector))
         {
             activeConnections.Add(ownedConnector);


### PR DESCRIPTION
- If method was called on a BuildingBlock that had a non-BuildingBlock object as it's root, a NullReferenceException would be thrown